### PR TITLE
Remove redundant nil checks

### DIFF
--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -106,10 +106,8 @@ func DeleteTablet(ctx context.Context, ts *topo.Server, tablet *topodatapb.Table
 // TabletIdent returns a concise string representation of this tablet.
 func TabletIdent(tablet *topodatapb.Tablet) string {
 	tagStr := ""
-	if tablet.Tags != nil {
-		for key, val := range tablet.Tags {
-			tagStr = tagStr + fmt.Sprintf(" %s=%s", key, val)
-		}
+	for key, val := range tablet.Tags {
+		tagStr = tagStr + fmt.Sprintf(" %s=%s", key, val)
 	}
 
 	return fmt.Sprintf("%s-%d (%s%s)", tablet.Alias.Cell, tablet.Alias.Uid, tablet.Hostname, tagStr)


### PR DESCRIPTION
These nil checks before the range loop are redundant (see https://staticcheck.io/docs/gosimple#S1031)